### PR TITLE
No connection ever => Better usability on first time login.

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -217,9 +217,14 @@
         const lastUpdate = this.syncData.last_extended > this.syncData.last_soc ?
           this.syncData.last_extended : this.syncData.last_soc;
 
-        this.dataOutdatedMessage =
-          `Data outdated. Updated ${this.$root.MomentJS(new Date(lastUpdate * 1000)).fromNow()}.`;
-        this.dataOutdatedMessageTimestamp = `(${this.$root.MomentJS(new Date(lastUpdate * 1000)).format('MMMM Do YYYY HH:mm')})`;
+        if(!lastUpdate) {
+          this.dataOutdatedMessage = `There has never been a connection to a car. Please connect your car first time.`
+        }
+        else {
+          this.dataOutdatedMessage =
+                  `Data outdated. Updated ${this.$root.MomentJS(new Date(lastUpdate * 1000)).fromNow()}.`;
+          this.dataOutdatedMessageTimestamp = `(${this.$root.MomentJS(new Date(lastUpdate * 1000)).format('MMMM Do YYYY HH:mm')})`;
+        }
         return !lastUpdate || lastUpdate + 600 < now;
       },
       isSupportedCar() {

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -219,8 +219,7 @@
 
         if(!lastUpdate) {
           this.dataOutdatedMessage = `There has never been a connection to a car. Please connect your car first time.`
-        }
-        else {
+        } else {
           this.dataOutdatedMessage =
                   `Data outdated. Updated ${this.$root.MomentJS(new Date(lastUpdate * 1000)).fromNow()}.`;
           this.dataOutdatedMessageTimestamp = `(${this.$root.MomentJS(new Date(lastUpdate * 1000)).format('MMMM Do YYYY HH:mm')})`;


### PR DESCRIPTION
Just added a better first time login message when no data has ever been there. If you want another one I can change this message.

![image](https://user-images.githubusercontent.com/25208775/58501050-c4904980-8183-11e9-82d9-2780e4c56bf9.png)

