### PR TITLE
Show header toolbar only when needed / relevant for saving. Otherwise…

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,18 +1,20 @@
 <template>
-    <v-toolbar app absolute ref="header" v-if="saved">
-        <v-toolbar-title class="headline">
-            <span>EVNotify</span>
-            <span class="font-weight-light hidden-xs-only">Webinterface</span>
-        </v-toolbar-title>
-        <v-spacer></v-spacer>
-        <v-expand-transition>
-            <div v-show="saved">
-                <v-btn flat color="teal" class="save-btn" @click="emitSave()">
-                    <v-icon>save</v-icon>
-                </v-btn>
-            </div>
-        </v-expand-transition>
-    </v-toolbar>
+    <v-expand-transition>
+        <v-toolbar app absolute ref="header" v-if="saved">
+            <v-toolbar-title class="headline">
+                <span>EVNotify</span>
+                <span class="font-weight-light hidden-xs-only">Webinterface</span>
+            </v-toolbar-title>
+            <v-spacer></v-spacer>
+            <v-expand-transition>
+                <div v-show="saved">
+                    <v-btn flat color="teal" class="save-btn" @click="emitSave()">
+                        <v-icon>save</v-icon>
+                    </v-btn>
+                </div>
+            </v-expand-transition>
+        </v-toolbar>
+    </v-expand-transition>
 </template>
 
 <script>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,7 +1,7 @@
 <template>
-    <v-toolbar app absolute ref="header">
+    <v-toolbar app absolute ref="header" v-if="saved">
         <v-toolbar-title class="headline">
-            <span>EVNotify </span>
+            <span>EVNotify</span>
             <span class="font-weight-light hidden-xs-only">Webinterface</span>
         </v-toolbar-title>
         <v-spacer></v-spacer>
@@ -12,7 +12,6 @@
                 </v-btn>
             </div>
         </v-expand-transition>
-
     </v-toolbar>
 </template>
 


### PR DESCRIPTION
… its useless and will not be displayed anymore => Get more informations on dashboard without scrolling. Removed some unnecessary spaces in code.