### PR TITLE
Add estimated finish Time next to "charge time left"

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -139,6 +139,7 @@
 <script>
   import storage from '../utils/storage';
   import cars from '../utils/cars';
+  import general from '../utils/general';
 
   export default {
     data: () => ({
@@ -175,29 +176,10 @@
         return 'red';
       },
       chargingTimeLeft() {
-        const capacity = cars[this.settings.car].CAPACITY;
-        const soc = this.syncData.soc_display || this.syncData.soc_bms;
-        const amountToCharge = capacity - parseFloat(
-          capacity * ((soc === 100) ? 1 : '0.' + ((soc < 10) ? ('0' + parseInt(soc)) : parseInt(soc)))
-        ).toFixed(2) || 0;
-        const decimalTime = parseFloat(
-          amountToCharge / (Math.abs(this.syncData.dc_battery_power) || cars[this.settings.car].FAST_SPEED)
-        ).toFixed(2);
-        const duration = this.$root.MomentJS.duration(parseFloat(decimalTime)).asMilliseconds();
-        return this.$root.MomentJS().startOf('day').add(duration, 'minutes').format('m:ss');
+        return general.chargeTime(this.settings.car, this.syncData.soc_display, this.syncData.soc_bms, this.syncData.dc_battery_power, "timeleft");
       },
       finishTime() {
-        const capacity = cars[this.settings.car].CAPACITY;
-        const soc = this.syncData.soc_display || this.syncData.soc_bms;
-        const amountToCharge = capacity - parseFloat(
-                capacity * ((soc === 100) ? 1 : '0.' + ((soc < 10) ? ('0' + parseInt(soc)) : parseInt(soc)))
-        ).toFixed(2) || 0;
-        const decimalTime = parseFloat(
-                amountToCharge / (Math.abs(this.syncData.dc_battery_power) || cars[this.settings.car].FAST_SPEED)
-        ).toFixed(2);
-        const duration = this.$root.MomentJS.duration(parseFloat(decimalTime)).asMilliseconds();
-        const now = new Date().getTime();
-        return this.$root.MomentJS(now).add(duration, 'hours').format('HH:mm');
+        return general.chargeTime(this.settings.car, this.syncData.soc_display, this.syncData.soc_bms, this.syncData.dc_battery_power, "finishtime");
       },
       currentRange() {
         const soc = this.syncData.soc_display || this.syncData.soc_bms;

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -39,7 +39,7 @@
                     <v-icon color="teal">schedule</v-icon>
                   </v-list-tile-action>
                   <v-list-tile-content>
-                    <v-list-tile-title>{{ chargingTimeLeft}} h</v-list-tile-title>
+                    <v-list-tile-title>{{ chargingTimeLeft }} h / {{ finishTime }}</v-list-tile-title>
                   </v-list-tile-content>
                 </v-list-tile>
               </v-list>
@@ -185,6 +185,19 @@
         ).toFixed(2);
         const duration = this.$root.MomentJS.duration(parseFloat(decimalTime)).asMilliseconds();
         return this.$root.MomentJS().startOf('day').add(duration, 'minutes').format('m:ss');
+      },
+      finishTime() {
+        const capacity = cars[this.settings.car].CAPACITY;
+        const soc = this.syncData.soc_display || this.syncData.soc_bms;
+        const amountToCharge = capacity - parseFloat(
+                capacity * ((soc === 100) ? 1 : '0.' + ((soc < 10) ? ('0' + parseInt(soc)) : parseInt(soc)))
+        ).toFixed(2) || 0;
+        const decimalTime = parseFloat(
+                amountToCharge / (Math.abs(this.syncData.dc_battery_power) || cars[this.settings.car].FAST_SPEED)
+        ).toFixed(2);
+        const duration = this.$root.MomentJS.duration(parseFloat(decimalTime)).asMilliseconds();
+        const now = new Date().getTime();
+        return this.$root.MomentJS(now).add(duration, 'hours').format('HH:mm');
       },
       currentRange() {
         const soc = this.syncData.soc_display || this.syncData.soc_bms;

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -39,7 +39,7 @@
                     <v-icon color="teal">schedule</v-icon>
                   </v-list-tile-action>
                   <v-list-tile-content>
-                    <v-list-tile-title>{{ chargingTimeLeft }} h / {{ finishTime }}</v-list-tile-title>
+                    <v-list-tile-title>{{ chargingTimeLeft }} h ({{ finishTime }})</v-list-tile-title>
                   </v-list-tile-content>
                 </v-list-tile>
               </v-list>

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -1,0 +1,35 @@
+import cars from '../utils/cars';
+import MomentJS from 'moment';
+
+export default {
+
+    /**
+     * Calculates chargetime left and finishtime while charging
+     * @param {String} car the cartype to get the chargetime to
+     * @param {String} socDisplay the state of charge from display
+     * @param {String} socBMS the state of charge from BMS
+     * @param {String} batteryPower the charging speed
+     * @param {String} typeOfTime the result timeType that gets returned
+     * @returns {*} the defined and calculated timeType
+     */
+    chargeTime: (car, socDisplay, socBMS, batteryPower, typeOfTime) => {
+        const capacity = cars[car].CAPACITY;
+        const soc = socDisplay || socBMS;
+        const amountToCharge = capacity - parseFloat(
+            capacity * ((soc === 100) ? 1 : '0.' + ((soc < 10) ? ('0' + parseInt(soc)) : parseInt(soc)))
+        ).toFixed(2) || 0;
+        const decimalTime = parseFloat(
+            amountToCharge / (Math.abs(batteryPower) || cars[car].FAST_SPEED)
+        ).toFixed(2);
+        const duration = MomentJS.duration(parseFloat(decimalTime)).asMilliseconds();
+        const now = new Date().getTime();
+        if(typeOfTime == "timeleft") {
+            return MomentJS().startOf('day').add(duration, 'minutes').format('m:ss');
+        } else if (typeOfTime == "finishtime") {
+            return MomentJS(now).add(duration, 'hours').format('HH:mm');
+        } else {
+            return false;
+        }
+
+    }
+}

--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -2,7 +2,6 @@ import cars from '../utils/cars';
 import MomentJS from 'moment';
 
 export default {
-
     /**
      * Calculates chargetime left and finishtime while charging
      * @param {String} car the cartype to get the chargetime to
@@ -30,6 +29,5 @@ export default {
         } else {
             return false;
         }
-
     }
 }


### PR DESCRIPTION
Solution for issue: https://github.com/EVNotify/EVNotifyPWA/issues/13

![Bildschirmfoto 2019-05-29 um 17 25 31](https://user-images.githubusercontent.com/25208775/58569934-57d68700-8237-11e9-846e-034319cfb6b0.png)

I copied the existing function chargingTimeLeft(). Maybe we can globalize some constants to deduplicate some code there. 