### PR TITLE
Added explanation for empty value cumulative charged..

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -93,7 +93,7 @@
                   <v-list-tile-sub-title>Battery current</v-list-tile-sub-title>
                 </v-list-tile-content>
               </v-list-tile>
-              <v-list-tile class="double-line" v-if="cumulative_energy_charged > 0 || cumulative_energy_charged > 0">
+              <v-list-tile class="double-line" v-if="syncData.cumulative_energy_charged > 0 || syncData.cumulative_energy_discharged > 0">
                 <v-list-tile-action>
                   <v-icon color="teal">battery_unknown</v-icon>
                 </v-list-tile-action>

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -2,7 +2,7 @@
   <v-layout>
     <v-dialog v-model="showBtnNotImplementedExplaination" max-width="290" persistent scrollable>
       <v-card>
-        <v-card-title class="headline">This Value is empty</v-card-title>
+        <v-card-title class="headline">This Value is empty?</v-card-title>
         <v-card-text>
           For users with EvNotiPi / Plug'n'Play devices this value is not implemented at the moment. But it will follow soon, don´t worry.<br><br>
         </v-card-text>

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -2,7 +2,7 @@
   <v-layout>
     <v-dialog v-model="showBtnNotImplementedExplaination" max-width="290" persistent scrollable>
       <v-card>
-        <v-card-title class="headline">This Value is empty?</v-card-title>
+        <v-card-title class="headline">This value is empty?</v-card-title>
         <v-card-text>
           For users with EvNotiPi / Plug'n'Play devices this value is not implemented at the moment. But it will follow soon, don´t worry.<br><br>
         </v-card-text>

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -1,5 +1,17 @@
 <template>
   <v-layout>
+    <v-dialog v-model="showBtnNotImplementedExplaination" max-width="290" persistent scrollable>
+      <v-card>
+        <v-card-title class="headline">This Value is empty</v-card-title>
+        <v-card-text>
+          For users with EvNotiPi / Plug'n'Play devices this value is not implemented at the moment. But it will follow soon, don´t worry.<br><br>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="green darken-1" flat @click="showBtnNotImplementedExplaination = false">Close</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
     <v-flex xs12 sm6 offset-sm3>
       <v-card class="main-card">
         <v-card-title primary-title>
@@ -101,6 +113,11 @@
                   <v-list-tile-title>{{ syncData.cumulative_energy_charged || 0 }} kWh / {{ syncData.cumulative_energy_discharged || 0 }} kWh </v-list-tile-title>
                   <v-list-tile-sub-title>Cumulative energy charged / <br> Cumulative energy discharged</v-list-tile-sub-title>
                 </v-list-tile-content>
+                <v-list-tile-action>
+                  <v-btn icon ripple @click="showBtnNotImplementedExplaination = true">
+                    <v-icon color="grey lighten-1">info</v-icon>
+                  </v-btn>
+                </v-list-tile-action>
               </v-list-tile>
               <v-subheader>Battery health</v-subheader>
               <v-list-tile v-if="syncData.soc_display">
@@ -167,7 +184,8 @@ import { setInterval } from 'timers';
       updatedTimestamp: '',
       dataOutdatedMessage: '',
       dataOutdatedMessageTimestamp: '',
-      settings: storage.getValue('settings', {})
+      settings: storage.getValue('settings', {}),
+      showBtnNotImplementedExplaination: false
     }),
     computed: {
       cycleColor() {

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -1,17 +1,5 @@
 <template>
   <v-layout>
-    <v-dialog v-model="showBtnNotImplementedExplaination" max-width="290" persistent scrollable>
-      <v-card>
-        <v-card-title class="headline">This value is empty?</v-card-title>
-        <v-card-text>
-          For users with EvNotiPi / Plug'n'Play devices this value is not implemented at the moment. But it will follow soon, don´t worry.<br><br>
-        </v-card-text>
-        <v-card-actions>
-          <v-spacer></v-spacer>
-          <v-btn color="green darken-1" flat @click="showBtnNotImplementedExplaination = false">Close</v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
     <v-flex xs12 sm6 offset-sm3>
       <v-card class="main-card">
         <v-card-title primary-title>
@@ -105,7 +93,7 @@
                   <v-list-tile-sub-title>Battery current</v-list-tile-sub-title>
                 </v-list-tile-content>
               </v-list-tile>
-              <v-list-tile class="double-line">
+              <v-list-tile class="double-line" v-if="cumulative_energy_charged > 0 || cumulative_energy_charged > 0">
                 <v-list-tile-action>
                   <v-icon color="teal">battery_unknown</v-icon>
                 </v-list-tile-action>
@@ -113,11 +101,6 @@
                   <v-list-tile-title>{{ syncData.cumulative_energy_charged || 0 }} kWh / {{ syncData.cumulative_energy_discharged || 0 }} kWh </v-list-tile-title>
                   <v-list-tile-sub-title>Cumulative energy charged / <br> Cumulative energy discharged</v-list-tile-sub-title>
                 </v-list-tile-content>
-                <v-list-tile-action>
-                  <v-btn icon ripple @click="showBtnNotImplementedExplaination = true">
-                    <v-icon color="grey lighten-1">info</v-icon>
-                  </v-btn>
-                </v-list-tile-action>
               </v-list-tile>
               <v-subheader>Battery health</v-subheader>
               <v-list-tile v-if="syncData.soc_display">
@@ -184,8 +167,7 @@ import { setInterval } from 'timers';
       updatedTimestamp: '',
       dataOutdatedMessage: '',
       dataOutdatedMessageTimestamp: '',
-      settings: storage.getValue('settings', {}),
-      showBtnNotImplementedExplaination: false
+      settings: storage.getValue('settings', {})
     }),
     computed: {
       cycleColor() {


### PR DESCRIPTION
... especially for PnP users this is an useful information, I think. Maybe we can check, if values are 0 and only then print the Info icon?