### PR TITLE
Save space by putting some values side by side each other. Changed …

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -89,31 +89,37 @@
                 </v-list-tile-content>
               </v-list-tile>
               <v-subheader>Battery data</v-subheader>
-              <v-list-tile>
-                <v-list-tile-action>
-                  <v-icon color="teal">battery_charging_full</v-icon>
-                </v-list-tile-action>
-                <v-list-tile-content>
-                  <v-list-tile-title>{{ syncData.dc_battery_voltage || 0 }} V</v-list-tile-title>
-                  <v-list-tile-sub-title>Battery voltage</v-list-tile-sub-title>
-                </v-list-tile-content>
-              </v-list-tile>
-              <v-list-tile>
-                <v-list-tile-action>
-                  <v-icon color="teal">power</v-icon>
-                </v-list-tile-action>
-                <v-list-tile-content>
-                  <v-list-tile-title>{{ syncData.dc_battery_current || 0 }} A</v-list-tile-title>
-                  <v-list-tile-sub-title>Battery current</v-list-tile-sub-title>
-                </v-list-tile-content>
-              </v-list-tile>
+              <v-layout row wrap>
+                <v-flex xs6>
+                  <v-list-tile>
+                    <v-list-tile-action>
+                      <v-icon color="teal">battery_charging_full</v-icon>
+                    </v-list-tile-action>
+                    <v-list-tile-content>
+                      <v-list-tile-title>{{ syncData.dc_battery_voltage || 0 }} V</v-list-tile-title>
+                      <v-list-tile-sub-title>Voltage</v-list-tile-sub-title>
+                    </v-list-tile-content>
+                  </v-list-tile>
+                </v-flex>
+                <v-flex xs6>
+                  <v-list-tile>
+                    <v-list-tile-action>
+                      <v-icon color="teal">power</v-icon>
+                    </v-list-tile-action>
+                    <v-list-tile-content>
+                      <v-list-tile-title>{{ syncData.dc_battery_current || 0 }} A</v-list-tile-title>
+                      <v-list-tile-sub-title>Current</v-list-tile-sub-title>
+                    </v-list-tile-content>
+                  </v-list-tile>
+                </v-flex>
+              </v-layout>
               <v-list-tile class="double-line" v-if="syncData.cumulative_energy_charged > 0 || syncData.cumulative_energy_discharged > 0">
                 <v-list-tile-action>
                   <v-icon color="teal">battery_unknown</v-icon>
                 </v-list-tile-action>
                 <v-list-tile-content>
                   <v-list-tile-title>{{ syncData.cumulative_energy_charged || 0 }} kWh / {{ syncData.cumulative_energy_discharged || 0 }} kWh </v-list-tile-title>
-                  <v-list-tile-sub-title>Cumulative energy charged / <br> Cumulative energy discharged</v-list-tile-sub-title>
+                  <v-list-tile-sub-title>Charged / discharged all time</v-list-tile-sub-title>
                 </v-list-tile-content>
               </v-list-tile>
               <v-subheader>Battery health</v-subheader>
@@ -277,11 +283,6 @@ import { setInterval } from 'timers';
     width: 100%;
   }
 
-  .layout {
-    width: 100%;
-    min-height: 100vh;
-  }
-
   .v-card.main-card {
     height: 100%;
   }
@@ -331,6 +332,9 @@ import { setInterval } from 'timers';
   .socexplainationmodal {
     position: absolute;
     margin-left: -5px;
+  }
+  .v-list__tile__action {
+    min-width: 35px;
   }
 </style>
 


### PR DESCRIPTION
…some wording because "battery" already in subheader. Not needed to tell twice. Deleted <v-layout> manipulation to get ability to use v-layout as intended.

<img width="414" alt="Bildschirmfoto 2019-07-26 um 23 21 18" src="https://user-images.githubusercontent.com/25208775/61982213-4c67c800-affc-11e9-8c14-f66624633765.png">
