### PR TITLE
More space top to bottom on dashboard. Changed some naming and..

### DIFF
--- a/src/components/BottomNavigation.vue
+++ b/src/components/BottomNavigation.vue
@@ -1,24 +1,22 @@
 <template>
-    <v-layout>
-        <v-bottom-nav :value="true" fixed color="transparent">
-            <v-btn flat color="teal" value="Dashboard" to="/">
-                <span>Dashboard</span>
-                <v-icon>dashboard</v-icon>
-            </v-btn>
-            <v-btn flat color="teal" value="Logs" to="/logs">
-                <span>Logs</span>
-                <v-icon>list</v-icon>
-            </v-btn>
-            <v-btn flat color="teal" value="Stations">
-                <span>Stations</span>
-                <v-icon>ev_station</v-icon>
-            </v-btn>
-            <v-btn flat color="teal" value="Settings" to="/settings">
-                <span>Settings</span>
-                <v-icon>settings</v-icon>
-            </v-btn>
-        </v-bottom-nav>
-    </v-layout>
+    <v-bottom-nav :value="true" fixed color="transparent">
+        <v-btn flat color="teal" value="Dashboard" to="/">
+            <span>Dashboard</span>
+            <v-icon>dashboard</v-icon>
+        </v-btn>
+        <v-btn flat color="teal" value="Logs" to="/logs">
+            <span>Logs</span>
+            <v-icon>list</v-icon>
+        </v-btn>
+        <v-btn flat color="teal" value="Stations">
+            <span>Stations</span>
+            <v-icon>ev_station</v-icon>
+        </v-btn>
+        <v-btn flat color="teal" value="Settings" to="/settings">
+            <span>Settings</span>
+            <v-icon>settings</v-icon>
+        </v-btn>
+    </v-bottom-nav>
 </template>
 
 <script>

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -344,6 +344,9 @@
   .v-list__tile__action {
     min-width: 35px;
   }
+  .full-height {
+    min-height: 100vh;
+  }
 </style>
 
 <style>
@@ -352,8 +355,5 @@
   }
   .v-list--two-line .double-line .v-list__tile {
     height: 70px;
-  }
-  .full-height {
-    min-height: 100vh;
   }
 </style>

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -92,7 +92,7 @@
                   <v-list-tile-sub-title>Min / Max / Inlet</v-list-tile-sub-title>
                 </v-list-tile-content>
               </v-list-tile>
-              <v-subheader>Battery data</v-subheader>
+              <v-subheader class="mt-2">Battery data</v-subheader>
               <v-layout row wrap>
                 <v-flex xs6>
                   <v-list-tile>
@@ -126,7 +126,7 @@
                   <v-list-tile-sub-title>Charged / discharged all time</v-list-tile-sub-title>
                 </v-list-tile-content>
               </v-list-tile>
-              <v-subheader>Battery health</v-subheader>
+              <v-subheader class="mt-2">Battery health</v-subheader>
               <v-layout row wrap>
                 <v-flex xs6>
                   <v-list-tile>

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -127,24 +127,30 @@
                 </v-list-tile-content>
               </v-list-tile>
               <v-subheader>Battery health</v-subheader>
-              <v-list-tile>
-                <v-list-tile-action>
-                  <v-icon color="teal">favorite</v-icon>
-                </v-list-tile-action>
-                <v-list-tile-content>
-                  <v-list-tile-title>{{ syncData.soh || 0 }} %</v-list-tile-title>
-                  <v-list-tile-sub-title>State of Health (SOH)</v-list-tile-sub-title>
-                </v-list-tile-content>
-              </v-list-tile>
-              <v-list-tile class="last-tile">
-                <v-list-tile-action>
-                  <v-icon color="teal">flash_auto</v-icon>
-                </v-list-tile-action>
-                <v-list-tile-content>
-                  <v-list-tile-title>{{ syncData.aux_battery_voltage || 0 }} V</v-list-tile-title>
-                  <v-list-tile-sub-title>Aux Battery Voltage</v-list-tile-sub-title>
-                </v-list-tile-content>
-              </v-list-tile>
+              <v-layout row wrap>
+                <v-flex xs6>
+                  <v-list-tile>
+                    <v-list-tile-action>
+                      <v-icon color="teal">favorite</v-icon>
+                    </v-list-tile-action>
+                    <v-list-tile-content>
+                      <v-list-tile-title>{{ syncData.soh || 0 }} %</v-list-tile-title>
+                      <v-list-tile-sub-title>State of Health</v-list-tile-sub-title>
+                    </v-list-tile-content>
+                  </v-list-tile>
+                </v-flex>
+                <v-flex xs6>
+                  <v-list-tile class="last-tile">
+                    <v-list-tile-action>
+                      <v-icon color="teal">flash_auto</v-icon>
+                    </v-list-tile-action>
+                    <v-list-tile-content>
+                      <v-list-tile-title>{{ syncData.aux_battery_voltage || 0 }} V</v-list-tile-title>
+                      <v-list-tile-sub-title>Aux Voltage</v-list-tile-sub-title>
+                    </v-list-tile-content>
+                  </v-list-tile>
+                </v-flex>
+              </v-layout>
             </v-list>
           </div>
         </v-card-title>

--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-layout>
+  <v-layout class="full-height">
     <v-dialog v-model="showSOCExplaination" max-width="290" persistent scrollable>
       <v-card>
         <v-card-title class="headline">State of charge</v-card-title>
@@ -352,5 +352,8 @@
   }
   .v-list--two-line .double-line .v-list__tile {
     height: 70px;
+  }
+  .full-height {
+    min-height: 100vh;
   }
 </style>

--- a/src/components/Log.vue
+++ b/src/components/Log.vue
@@ -216,7 +216,7 @@
                 return Math.abs((parseFloat((speeds.reduce((a, b) => a + b, 0) / speeds.length) || 0) * 3.6).toFixed(2));
             },
             distance() {
-                return (this.avgSpeed * (((this.log.end - this.log.start) / 3600)) || 0).toFixed(2);
+                return (this.avgSpeed * ((this.log.end - this.log.start) / 3600) || 0).toFixed(2);
             },
             kWChartValues() {
                 const powers = this.log.stats.filter((stat) => stat.dc_battery_power != null).map((stat) => {


### PR DESCRIPTION
... get a little more space between subheaders and the content for an easier view on dashboard.

Before:
<img width="424" alt="Bildschirmfoto 2019-07-27 um 13 46 50" src="https://user-images.githubusercontent.com/25208775/61993990-08fd7000-b075-11e9-8c13-800548a6d15f.png">

After:
<img width="438" alt="Bildschirmfoto 2019-07-27 um 13 47 37" src="https://user-images.githubusercontent.com/25208775/61993997-2c281f80-b075-11e9-91a5-b1c36b8a16fb.png">

