### PR TITLE
Preloading key requests of static resources to get better performance…

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, height=device-height, maximum-scale=1.0, user-scalable=no, viewport-fit=cover">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>EVNotify Webinterface</title>
+    <link rel="preload" href="<%= BASE_URL %>css/roboto.css" as="style">
+    <link rel="preload" href="<%= BASE_URL %>css/materialicons.css" as="style">
+    <link rel="preload" href="<%= BASE_URL %>leaflet/leaflet.css" as="style">
     <link rel="stylesheet" href="<%= BASE_URL %>css/roboto.css">
     <link rel="stylesheet" href="<%= BASE_URL %>css/materialicons.css">
     <link rel="stylesheet" href="<%= BASE_URL %>leaflet/leaflet.css">


### PR DESCRIPTION
… when resources are needed. https://developers.google.com/web/tools/lighthouse/audits/preload

This is a result of lighthouse report and should improve page performance on chrome an safari. See here for compatibility. In browser with no compatibility the preload link will be ignored: https://caniuse.com/#feat=link-rel-preload

<img width="740" alt="Bildschirmfoto 2019-07-28 um 18 16 26" src="https://user-images.githubusercontent.com/25208775/62009855-ec8c3100-b163-11e9-842a-ed6d151d3aac.png">