### PR TITLE
Compatibility for landscape mode on mobile devices. Get rid of...

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-layout class="full-height">
+  <v-layout class="full-height" justify-center>
     <v-dialog v-model="showSOCExplaination" max-width="290" persistent scrollable>
       <v-card>
         <v-card-title class="headline">State of charge</v-card-title>
@@ -13,7 +13,7 @@
         </v-card-actions>
       </v-card>
     </v-dialog>
-    <v-flex xs12 sm6 offset-sm3>
+    <v-flex xs12 sm12 md6>
       <v-card class="main-card">
         <v-card-title primary-title>
           <v-layout class="upper-part">

--- a/src/components/Log.vue
+++ b/src/components/Log.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-layout>
+    <v-layout justify-center>
         <v-dialog v-model="showBtnExplaination" max-width="290" persistent scrollable>
             <v-card>
                 <v-card-title class="headline">Why?</v-card-title>
@@ -21,7 +21,7 @@
                 </v-card-actions>
             </v-card>
         </v-dialog>
-        <v-flex xs12 sm6 offset-sm3>
+        <v-flex xs12 sm12 md6>
             <v-card class="mx-auto" v-if="log.id" v-show="!showChart && !showMap">
                 <v-card-title>
                     <v-icon class="mr-5" size="64" @click="$router.push('/logs')">chevron_left</v-icon>

--- a/src/components/Logs.vue
+++ b/src/components/Logs.vue
@@ -1,6 +1,6 @@
 <template>
-    <v-layout>
-        <v-flex xs12 sm6 offset-sm3>
+    <v-layout justify-center>
+        <v-flex xs12 sm12 md6>
             <v-card>
                 <v-list two-line subheader v-if="loaded && Object.keys(logs).length">
                     <div v-for="(month, index) in logs" :key="index">

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -1,5 +1,5 @@
 <template>
-    <v-layout>
+    <v-layout justify-center>
         <v-dialog v-model="changePasswordDialog" persistent max-width="290">
             <v-card>
                 <v-card-title class="headline">Change password</v-card-title>
@@ -112,7 +112,7 @@
                 </v-card-actions>
             </v-card>
         </v-dialog>
-        <v-flex xs12 sm6 offset-sm3>
+        <v-flex xs12 sm12 md6>
             <v-form>
                 <v-list>
                     <v-list-group v-for="setting in settings" :key="setting.title" v-model="setting.active"


### PR DESCRIPTION
offset handling.

Now you're also able to view the log detail => chart in landscape mode with an even more detailed view on data because the screen is fully used. Also the click on detail  chart information is more accurate now.

On desktop viewport the app stays in centered 50/50 view to have better readability of content.

Removed the offset to use native possibility of justify-center attributes  

Before:
<img width="899" alt="Bildschirmfoto 2019-07-31 um 23 09 02" src="https://user-images.githubusercontent.com/25208775/62248396-443ace80-b3e8-11e9-9afc-e292968ea0a8.png">

After:
<img width="888" alt="Bildschirmfoto 2019-07-31 um 23 09 17" src="https://user-images.githubusercontent.com/25208775/62248400-48ff8280-b3e8-11e9-8604-0aa1dbcef614.png">
