### PR TITLE
Consumption correctly displayed on smaller devices by using native te…

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -49,7 +49,7 @@
                     </v-list-tile-action>
                     <v-list-tile-content>
                       <v-list-tile-title :style="{color: currentRangeColor}">{{ currentRange }} / {{ totalRange }} km</v-list-tile-title>
-                      <span class="font-weight-light font-italic">{{ settings.consumption || 0 }} kWh / 100 km</span>
+                      <span class="font-weight-light font-italic caption">{{ settings.consumption || 0 }} kWh / 100 km</span>
                     </v-list-tile-content>
                   </v-list-tile>
                   <v-list-tile v-if="syncData.charging && isSupportedCar()">


### PR DESCRIPTION
…xt size class

Before on iPhoneSE:
<img width="379" alt="Bildschirmfoto 2019-07-31 um 23 32 02" src="https://user-images.githubusercontent.com/25208775/62249868-c8db1c00-b3eb-11e9-994c-51344d0d155b.png">

After on iPhoneSE:
<img width="362" alt="Bildschirmfoto 2019-07-31 um 23 31 47" src="https://user-images.githubusercontent.com/25208775/62249873-cc6ea300-b3eb-11e9-9a08-e86eb3123626.png">
