### PR TITLE
Added spearator between robot and logs in dashboard. added "if" aroun…

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -153,7 +153,7 @@
                 </v-flex>
               </v-layout>
             </v-list>
-            <v-divider class="mt-1 mb-3"></v-divider>
+            <v-divider class="mt-1 mb-3" v-if="log.id"></v-divider>
             <v-list two-line subheader v-if="log.id">
               <v-subheader>Latest log</v-subheader>
                 <v-list-tile avatar @click="$router.push({name: 'log', query: {id: log.id}})">
@@ -171,6 +171,7 @@
                   </v-list-tile-action>
                 </v-list-tile>
             </v-list>
+            <v-divider class="mt-1 mb-3"></v-divider>
             <v-list two-line subheader>
               <v-subheader>Random robot of the day</v-subheader>
                 <v-list-tile avatar @click="$router.push('/robots')" class="last-tile">


### PR DESCRIPTION
…d divider so only displayed if logs are present. (preventing double divider)

Added divider:
<img width="358" alt="image" src="https://user-images.githubusercontent.com/25208775/63551751-39caab00-c536-11e9-9c71-78921e415e9f.png">

and preventing this problem:
<img width="362" alt="image" src="https://user-images.githubusercontent.com/25208775/63551777-4cdd7b00-c536-11e9-811b-f1a734d64192.png">
