### PR TITLE
Disable the stations button in bottom navigation for better usability

### DIFF
--- a/src/components/BottomNavigation.vue
+++ b/src/components/BottomNavigation.vue
@@ -8,7 +8,7 @@
             <span>Logs</span>
             <v-icon>list</v-icon>
         </v-btn>
-        <v-btn flat color="teal" value="Stations">
+        <v-btn flat disabled color="teal" value="Stations">
             <span>Stations</span>
             <v-icon>ev_station</v-icon>
         </v-btn>


### PR DESCRIPTION
Before: Clickable and users are irritated because button works but has no function. Now its disabled and not clickable but users maybe knows, that this is an upcoming feature.

Better should be to list "coming soon" in a hover or tooltip. 

Before:
<img width="441" alt="image" src="https://user-images.githubusercontent.com/25208775/65920230-c6427600-e3de-11e9-95a4-7ca7da460b26.png">

After:
<img width="490" alt="image" src="https://user-images.githubusercontent.com/25208775/65920206-b7f45a00-e3de-11e9-97fb-b20494d3f7fe.png">
