### PR TITLE
Added Browserconfig to get tile icon in Windows 8 and Windows 10

### DIFF
--- a/public/browserconfig.xml
+++ b/public/browserconfig.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<browserconfig>
+    <msapplication>
+        <tile>
+            <square150x150logo src="./img/icons/mstile-150x150.png"/>
+            <TileColor>#da532c</TileColor>
+        </tile>
+    </msapplication>
+</browserconfig>


### PR DESCRIPTION
Fixed this Problem: 
<img width="1186" alt="image" src="https://user-images.githubusercontent.com/25208775/65995638-395af380-e496-11e9-87e0-830f44a5e782.png">
