### PR TITLE
Hide outdated consumption information for less confusion.

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -36,8 +36,8 @@
             <v-flex xs7>
               <div class="progress-cycle-container">
                 <v-list>
-                  <v-list-tile>
-                    <v-list-tile-action>
+                  <v-list-tile v-if="!dataOutdated()">
+                    <v-list-tile-action >
                       <v-icon color="teal">flash_on</v-icon>
                     </v-list-tile-action>
                     <v-list-tile-content>


### PR DESCRIPTION
Before:
<img width="434" alt="image" src="https://user-images.githubusercontent.com/25208775/66708098-afd7db00-ed4b-11e9-902f-0ef63e4b4d73.png">


After:
<img width="434" alt="image" src="https://user-images.githubusercontent.com/25208775/66708094-a51d4600-ed4b-11e9-9a91-33b8df920ca9.png">
