### PR TITLE
Better readability for some text in dashboard while in dark mode.

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -298,7 +298,12 @@
         if (this.currentRange < (this.totalRange * 10 / 100)) {
           return 'red';
         }
-        return 'green';
+        if(storage.getValue('darkMode', false) == true) {
+          return 'chartreuse';
+        }
+        else {
+          return 'green';
+        }
       },
       totalRange() {
         return parseInt((cars[this.settings.car].CAPACITY / this.settings.consumption) * 100) || 0;
@@ -310,10 +315,18 @@
     },
     methods: {
       getTemperatureColor(temperature) {
-        if (temperature < 20) return 'blue';
-        else if (temperature < 30) return 'green';
-        else if (temperature < 35) return 'orange';
-        return 'red';
+        if(storage.getValue('darkMode', false) == true) {
+          if (temperature < 20) return 'deepskyblue';
+          else if (temperature < 30) return 'chartreuse';
+          else if (temperature < 35) return 'orange';
+          return 'red';
+        }
+        else {
+          if (temperature < 20) return 'blue';
+          else if (temperature < 30) return 'green';
+          else if (temperature < 35) return 'orange';
+          return 'red';
+        }
       },
       fetchData() {
         const self = this;
@@ -447,6 +460,10 @@
     margin-bottom: 0;
     text-align: center;
     color: #009688;
+  }
+
+  .theme--dark .progress-cycle-container p {
+    color: white;
   }
 
   .temperature-text {


### PR DESCRIPTION
I changed the green color in dark mode to chartreuse green and the dark blue to a deepskyblue to be able to read the numbers in dark mode. Only in dark rooms this was possible. More contrast was needed.

Before:
<img width="485" alt="image" src="https://user-images.githubusercontent.com/25208775/71448799-7d7e2d00-2741-11ea-9b6f-20c640db46c4.png">


After:
<img width="482" alt="image" src="https://user-images.githubusercontent.com/25208775/71448797-75be8880-2741-11ea-8bab-f14310b55bcf.png">
