### PR TITLE
Changed Robot Subtitle => Title to have same color like the other til…

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -182,8 +182,8 @@
                     <v-img v-else :src="randomRobotAvatar"></v-img>
                   </v-list-tile-avatar>
                   <v-list-tile-content>
-                    <v-list-tile-sub-title v-if="!randomRobot.id" class="quote-title">No robot yet. They are waiting here, if you click me.</v-list-tile-sub-title>
-                    <v-list-tile-sub-title v-else class="quote-title">{{ randomRobot.quote }}</v-list-tile-sub-title>
+                    <v-list-tile-title v-if="!randomRobot.id" class="quote-title">No robot yet. They are waiting here, if you click me.</v-list-tile-title>
+                    <v-list-tile-title v-else class="quote-title">{{ randomRobot.quote }}</v-list-tile-title>
                   </v-list-tile-content>
                   <v-list-tile-action>
                     <v-btn icon ripple @click="$router.push('/robots')">


### PR DESCRIPTION
…es on dashboard in dark mode. Text was grey on black. For a normal tile this is not a good choice. 


Before:
<img width="478" alt="image" src="https://user-images.githubusercontent.com/25208775/71673503-4202e480-2d79-11ea-855a-210caf8b0fcb.png">


After:
<img width="482" alt="image" src="https://user-images.githubusercontent.com/25208775/71673483-34e5f580-2d79-11ea-927e-8bc9fb90833a.png">

Signed-off-by: Pazekal90 <mail@pascal-pischel.de>