### PR TITLE
Optimizing Chart for Dark Mode. Legend and Axis turn color to white …

### DIFF
--- a/src/components/Log.vue
+++ b/src/components/Log.vue
@@ -112,6 +112,7 @@
 
 <script>
     import { Line } from 'vue-chartjs';
+    import storage from '../utils/storage';
 
     export default {
         data: () => ({
@@ -277,6 +278,13 @@
                 return avgValues.reverse();
 
             },
+            sparklinecolor() {
+                if(storage.getValue('darkMode', false) == true) {
+                    return "white";
+                }
+                else
+                    return "black";
+            },
             chartData() {
                 const self = this;
                 const stats = [...self.log.stats].sort((a, b) => a.timestamp - b.timestamp);
@@ -359,9 +367,20 @@
                                     xAxes: [{
                                         ticks: {
                                             autoSkip: true,
-                                            maxTicksLimit: 15
+                                            maxTicksLimit: 15,
+                                            fontColor: this.sparklinecolor
                                         }
-                                    }]   
+                                    }],
+                                    yAxes: [{
+                                        ticks:{
+                                            fontColor: this.sparklinecolor
+                                        }
+                                    }]
+                                },
+                                legend: {
+                                    labels: {
+                                        fontColor: this.sparklinecolor
+                                    }
                                 }
                             });
                         });


### PR DESCRIPTION
…in dark mode.

Before:
<img width="483" alt="image" src="https://user-images.githubusercontent.com/25208775/71695462-7ba41180-2db2-11ea-8baf-39e528517e07.png">

After:
<img width="488" alt="image" src="https://user-images.githubusercontent.com/25208775/71695479-8b235a80-2db2-11ea-87d2-8242120cdb09.png">


Signed-off-by: Pazekal90 <mail@pascal-pischel.de>