### PR TITLE
PowerAmount Color changed to a better readable color in dark mode.

### DIFF
--- a/src/components/Dashboard.vue
+++ b/src/components/Dashboard.vue
@@ -279,7 +279,14 @@
         return (Math.abs(this.syncData.dc_battery_power) || 0).toFixed(2);
       },
       powerAmountColor() {
-        if (this.syncData.charging) return 'green';
+        if(this.syncData.charging) {
+          if(storage.getValue('darkMode', false) == true) {
+            return 'chartreuse';
+          }
+          else {
+            return 'green';
+          }
+        }
         return parseFloat(this.syncData.dc_battery_power) <= 0 ? '#009688' : 'red';
       },
       chargingTimeLeft() {


### PR DESCRIPTION
Color in normal mode stays the same as before. 

Before:
<img width="472" alt="image" src="https://user-images.githubusercontent.com/25208775/71735212-26b5d900-2e4e-11ea-93c6-545051de2666.png">

After:
<img width="490" alt="image" src="https://user-images.githubusercontent.com/25208775/71735222-2e757d80-2e4e-11ea-93e2-0f63ffe5a72b.png">
