### PR TITLE
Show average consumption on trip log

### DIFF
--- a/src/components/Log.vue
+++ b/src/components/Log.vue
@@ -60,7 +60,7 @@
                                     <div class="caption" v-if="log.charge">charged: {{ (endCEC - startCEC || 0).toFixed(1) }} kWh</div>
                                     <div class="caption" v-else>consumed: {{ (endCED - startCED || 0).toFixed(1)}} kWh<br>recuperated: {{ (endCEC - startCEC || 0).toFixed(1) }} kWh</div>
                                 </div>
-                                <div class="caption" v-if="!log.charge">Ø {{ (((endCED - startCED) - (endCEC - startCEC)) / distance * 100).toFixed(1) }} kWh/100km | Ø {{ avgSpeed }} km/h | {{ distance }} km driven</div>
+                                <div class="caption" v-if="!log.charge">Ø {{ ((((endCED - startCED) - (endCEC - startCEC)) || 0) / distance * 100).toFixed(1) }} kWh/100km | Ø {{ avgSpeed }} km/h | {{ distance }} km driven</div>
                             </v-flex>
                         </v-timeline-item>
                         <v-timeline-item class="mb-3" small color="accent">

--- a/src/components/Log.vue
+++ b/src/components/Log.vue
@@ -60,7 +60,7 @@
                                     <div class="caption" v-if="log.charge">charged: {{ (endCEC - startCEC || 0).toFixed(1) }} kWh</div>
                                     <div class="caption" v-else>consumed: {{ (endCED - startCED || 0).toFixed(1)}} kWh<br>recuperated: {{ (endCEC - startCEC || 0).toFixed(1) }} kWh</div>
                                 </div>
-                                <div class="caption" v-if="!log.charge">Ø {{ avgSpeed }} km/h | {{ distance }} km driven</div>
+                                <div class="caption" v-if="!log.charge">Ø {{ (((endCED - startCED) - (endCEC - startCEC)) / distance * 100).toFixed(1) }} kWh/100km | Ø {{ avgSpeed }} km/h | {{ distance }} km driven</div>
                             </v-flex>
                         </v-timeline-item>
                         <v-timeline-item class="mb-3" small color="accent">


### PR DESCRIPTION
I think that one of the most interesting statistics is the average consumption on each trip. However it is displayed nowhere?

This PR would add this to the log. However I am not sure if the method of calculation I used is really correct. Found [this thread](https://www.goingelectric.de/forum/viewtopic.php?f=118&t=49882) which has some doubts.