### PR TITLE
simplify chargeDecimalTime

### DIFF
--- a/src/utils/general.js
+++ b/src/utils/general.js
@@ -25,9 +25,7 @@ export default {
     chargeDecimalTime(car, socDisplay, socBMS, batteryPower) {
         const capacity = cars[car].CAPACITY;
         const soc = socDisplay || socBMS;
-        const amountToCharge = capacity - parseFloat(
-            capacity * ((soc === 100) ? 1 : '0.' + ((soc < 10) ? ('0' + parseInt(soc)) : parseInt(soc)))
-        ).toFixed(2) || 0;
+        const amountToCharge = capacity * (1 - (soc / 100)) || 0;
         const decimalTime = parseFloat(
             amountToCharge / (Math.abs(batteryPower) || cars[car].FAST_SPEED)
         ).toFixed(2);


### PR DESCRIPTION
I was idling through the source code and than I found this:
```js
((soc === 100) ? 1 : '0.' + ((soc < 10) ? ('0' + parseInt(soc)) : parseInt(soc)))
```
I stared at it for a while. Not sure if I may be missing something... But... if the purpose is to divide by 100, then I think I know an algorithm which is a little more compact and should also perform quicker with less memory overhead.